### PR TITLE
Fix clang build runtime errors

### DIFF
--- a/src/gpu/GPUSimtPass.cpp
+++ b/src/gpu/GPUSimtPass.cpp
@@ -32,8 +32,8 @@
 
 using namespace mlir;
 
-namespace
-{
+namespace mlir {
+namespace decisionforest {
 
 struct TraverseToCooperativeTraverseTreeTileOp : public ConversionPattern {
   TraverseToCooperativeTraverseTreeTileOp(MLIRContext *ctx) 
@@ -84,14 +84,8 @@ struct ConvertTraverseToCooperativeTraverse: public PassWrapper<ConvertTraverseT
   }
 };
 
-} // anonymous namespace
-
-namespace mlir
-{
-namespace decisionforest
-{
-
-void LowerGPUEnsembleToMemrefs(mlir::MLIRContext& context, mlir::ModuleOp module) {
+void ConvertTraverseToSimtTraverse(mlir::MLIRContext &context,
+                                   mlir::ModuleOp module) {
   // llvm::DebugFlag = true;
   // Lower from high-level IR to mid-level IR
   mlir::PassManager pm(&context);
@@ -103,7 +97,7 @@ void LowerGPUEnsembleToMemrefs(mlir::MLIRContext& context, mlir::ModuleOp module
   }
 }
 
-} // decisionforest
-} // mlir
+} // namespace decisionforest
+} // namespace mlir
 
 #endif

--- a/src/gpu/GPUSupportUtils.cpp
+++ b/src/gpu/GPUSupportUtils.cpp
@@ -24,8 +24,10 @@
 
 using namespace mlir;
 
-namespace 
-{
+namespace mlir {
+namespace decisionforest {
+
+StringRef getMappingAttrName() { return "mapping"; }
 
 // Replace all uses of the input argument memref with the gpu memref inside
 // the gpu kernel
@@ -172,12 +174,6 @@ void AddGPUAllocationsAndTransfers(mlir::ModuleOp module) {
   });
 }
 
-} // anonymous namespace
-
-namespace mlir
-{
-namespace decisionforest
-{
 
 void GreedilyMapParallelLoopsToGPU(mlir::ModuleOp module) {
   mlir::PassManager pm(module.getContext());
@@ -220,7 +216,7 @@ void RunCanonicalizerPass(mlir::MLIRContext& context, mlir::ModuleOp module) {
   }
 }
 
-} // decisionforest
-} // mlir
+} // namespace decisionforest
+} // namespace mlir
 
 #endif // TREEBEARD_GPU_SUPPORT

--- a/src/gpu/LowerGPUToLLVM.cpp
+++ b/src/gpu/LowerGPUToLLVM.cpp
@@ -69,8 +69,8 @@
 
 using namespace mlir;
 
-namespace
-{
+namespace mlir {
+namespace decisionforest {
 
 template <typename DerivedT>
 class ConvertGpuOpsToNVVMOpsBase : public ::mlir::OperationPass<gpu::GPUModuleOp> {
@@ -324,7 +324,8 @@ struct PrintModulePass : public PassWrapper<PrintModulePass, OperationPass<Modul
   }
 };
 
-} // namespace
+} // namespace decisionforest
+} // namespace mlir
 
 namespace mlir
 {

--- a/src/gpu/ReorgForestRepresentation.cpp
+++ b/src/gpu/ReorgForestRepresentation.cpp
@@ -23,8 +23,8 @@
 using namespace mlir;
 using namespace mlir::decisionforest::helpers;
 
-namespace
-{
+namespace mlir {
+namespace decisionforest {
 
 const int32_t kAlignedPointerIndexInMemrefStruct = 1;
 const int32_t kOffsetIndexInMemrefStruct = 2;
@@ -118,7 +118,8 @@ struct LoadTileFeatureIndicesOpLowering: public ConversionPattern {
   }
 };
 
-}
+} // namespace decisionforest
+} // namespace mlir
 
 namespace mlir
 {

--- a/src/mlir/ConvertNodeTypeToIndexType.cpp
+++ b/src/mlir/ConvertNodeTypeToIndexType.cpp
@@ -23,9 +23,8 @@
 #include "Logger.h"
 #include "OpLoweringUtils.h"
 
-using namespace mlir;
-
-namespace {
+namespace mlir {
+namespace decisionforest {
 
 struct NodeToIndexOpLowering : public ConversionPattern {
   NodeToIndexOpLowering(MLIRContext *ctx) : ConversionPattern(mlir::decisionforest::NodeToIndexOp::getOperationName(), 1 /*benefit*/, ctx) {}
@@ -74,7 +73,7 @@ struct IndexToNodeOpLowering : public ConversionPattern {
       return mlir::failure();
     }
     else {
-      assert (indexValue.getType().isa<IndexType>());
+      assert (indexValue.getType().isa<mlir::IndexType>());
       rewriter.replaceOp(op, indexValue);
     }
     return mlir::success();
@@ -125,7 +124,7 @@ struct ConvertNodeTypeToIndexTypePass : public PassWrapper<ConvertNodeTypeToInde
         for (auto operand : op->getOperands()) {
           if (operand.getType().isa<decisionforest::NodeType>()) {
             // TreeBeard::Logging::Log("Calling setType on argument of : " + op->getName().getStringRef().str());
-            operand.setType(IndexType::get(op->getContext()));
+            operand.setType(mlir::IndexType::get(op->getContext()));
           }
         }
     }
@@ -164,7 +163,8 @@ struct ConvertNodeTypeToIndexTypePass : public PassWrapper<ConvertNodeTypeToInde
         signalPassFailure();
   }
 };
-} // Anonymous namespace
+} // namespace decisionforest
+} // namespace mlir
 
 namespace mlir
 {

--- a/src/mlir/LowerDebugHelpers.cpp
+++ b/src/mlir/LowerDebugHelpers.cpp
@@ -13,9 +13,11 @@
 
 using namespace mlir;
 
-namespace
-{
-FlatSymbolRefAttr getOrInsertFunction(std::string& functionName, LLVM::LLVMFunctionType functionType, PatternRewriter &rewriter,
+namespace mlir {
+namespace decisionforest {
+FlatSymbolRefAttr getOrInsertFunction(std::string &functionName,
+                                      LLVM::LLVMFunctionType functionType,
+                                      PatternRewriter &rewriter,
                                       ModuleOp module) {
   auto *context = module.getContext();
   if (module.lookupSymbol<LLVM::LLVMFuncOp>(functionName))
@@ -348,7 +350,8 @@ struct PrintVectorOpLowering: public ConversionPattern {
   }
 };
 
-} // anonymous namespace
+} // namespace decisionforest
+} // namespace mlir
 
 namespace mlir
 {

--- a/src/mlir/LowerEnsembleToMemrefs.cpp
+++ b/src/mlir/LowerEnsembleToMemrefs.cpp
@@ -91,7 +91,8 @@ void GenerateSimpleInitializer(const std::string& funcName, ConversionPatternRew
 
 Value getLUT;
 
-namespace {
+namespace mlir {
+namespace decisionforest {
 
 struct EnsembleConstantOpLowering: public ConversionPattern {
   std::shared_ptr<decisionforest::IModelSerializer> m_serializer;
@@ -666,7 +667,8 @@ struct MidLevelIRToGPUMemrefLoweringPass: public PassWrapper<MidLevelIRToGPUMemr
   }
 };
 
-} // anonymous namespace
+} // namespace decisionforest
+} // namespace mlir
 
 namespace mlir
 {

--- a/src/mlir/LowerSparseEnsembleToMemrefs.cpp
+++ b/src/mlir/LowerSparseEnsembleToMemrefs.cpp
@@ -22,9 +22,8 @@
 #include "TraverseTreeTileOpLowering.h"
 #include "OpLoweringUtils.h"
 
-using namespace mlir;
-
-namespace {
+namespace mlir {
+namespace decisionforest {
 
 struct EnsembleConstantLoweringInfo {
   Value modelGlobal;
@@ -1099,7 +1098,8 @@ struct GetLeafTileValueOpLowering : public ConversionPattern {
   }
 };
 
-} // anonymous
+} // namespace decisionforest
+} // namespace mlir
 
 namespace mlir
 {
@@ -1124,5 +1124,5 @@ void PopulateLowerToSparseRepresentationPatterns(RewritePatternSet& patterns) {
                 GetLeafTileValueOpLowering>(patterns.getContext());
 }
 
-} // decisionforest
-} // mlir
+} // namespace decisionforest
+} // namespace mlir

--- a/src/mlir/LowerToLLVM.cpp
+++ b/src/mlir/LowerToLLVM.cpp
@@ -68,10 +68,6 @@ namespace decisionforest
 // Defined in LowerDebugHelpers.cpp
 void InsertPrintElementAddressIfNeeded(ConversionPatternRewriter& rewriter, Location location, ModuleOp module,
                                        Value extractMemrefBufferPointer, Value indexVal, Value actualIndex, Value elemIndexConst, Value elemPtr);
-}
-}
-
-namespace {
 
 struct DecisionForestToLLVMLoweringPass : public PassWrapper<DecisionForestToLLVMLoweringPass, OperationPass<ModuleOp>> {
   std::shared_ptr<decisionforest::IRepresentation> m_representation;
@@ -170,7 +166,8 @@ struct PrintModulePass : public PassWrapper<PrintModulePass, OperationPass<Modul
   }
 };
 
-} // end anonymous namespace
+} // namespace decisionforest
+} // namespace mlir
 
 namespace mlir
 {

--- a/src/mlir/LowerToMidLevelIR.cpp
+++ b/src/mlir/LowerToMidLevelIR.cpp
@@ -18,7 +18,8 @@
 
 using namespace mlir;
 
-namespace {
+namespace mlir {
+namespace decisionforest {
 
 static MemRefType getRowTypeFromArgumentType(MemRefType type) {
   assert (type.hasRank() && "expected only rank shapes");
@@ -1321,7 +1322,8 @@ struct HighLevelIRToMidLevelIRLoweringPass: public PassWrapper<HighLevelIRToMidL
   }
 };
 
-} // anonymous namespace
+} // namespace decisionforest
+} // namespace mlir
 
 namespace mlir
 {
@@ -1344,5 +1346,5 @@ void LowerFromHighLevelToMidLevelIR(mlir::MLIRContext& context, mlir::ModuleOp m
   // llvm::DebugFlag = false;
 }
 
-} // decisionforest
-} // mlir
+} // namespace decisionforest
+} // namespace mlir

--- a/src/mlir/ProbabilityBasedTilingTransform.cpp
+++ b/src/mlir/ProbabilityBasedTilingTransform.cpp
@@ -21,8 +21,8 @@
 #include "OpLoweringUtils.h"
 #include "TiledTree.h"
 
-using namespace mlir;
-namespace {
+namespace mlir {
+namespace decisionforest {
 
 struct TileEnsembleAttribute : public RewritePattern {
   int32_t m_tileSize;
@@ -232,7 +232,8 @@ struct ProbabilityBasedTilingPass : public PassWrapper<ProbabilityBasedTilingPas
         signalPassFailure();
   }
 };
-} // anonymous namespace
+} // namespace decisionforest
+} // namespace mlir
 
 namespace mlir
 {

--- a/src/mlir/ReorderTiledTreesByDepth.cpp
+++ b/src/mlir/ReorderTiledTreesByDepth.cpp
@@ -22,7 +22,8 @@
 
 using namespace mlir;
 
-namespace {
+namespace mlir {
+namespace decisionforest {
 
 template<typename T>
 T AssertOpIsOfType(Operation* operation) {
@@ -353,7 +354,8 @@ struct SplitTreeLoopByDepth : public PassWrapper<SplitTreeLoopByDepth, Operation
   }
 };
 
-} // anonymous namespace
+} // namespace decisionforest
+} // namespace mlir
 
 namespace mlir
 {

--- a/src/mlir/UniformTilingTransformation.cpp
+++ b/src/mlir/UniformTilingTransformation.cpp
@@ -21,8 +21,8 @@
 #include "OpLoweringUtils.h"
 #include "Dialect.h"
 
-using namespace mlir;
-namespace {
+namespace mlir {
+namespace decisionforest {
 
 struct TileEnsembleAttribute : public RewritePattern {
   int32_t m_tileSize;
@@ -143,7 +143,8 @@ struct UniformTilingPass : public PassWrapper<UniformTilingPass, OperationPass<m
         signalPassFailure();
   }
 };
-} // anonymous namespace
+} // namespace decisionforest
+} // namespace mlir
 
 namespace mlir
 {

--- a/src/mlir/WalkDecisionTreeLoweringPass.cpp
+++ b/src/mlir/WalkDecisionTreeLoweringPass.cpp
@@ -14,8 +14,8 @@
 
 using namespace mlir;
 
-namespace
-{
+namespace mlir {
+namespace decisionforest {
 
 struct WalkDecisionTreeOpLowering: public ConversionPattern {
   WalkDecisionTreeOpLowering(MLIRContext *ctx) : ConversionPattern(mlir::decisionforest::WalkDecisionTreeOp::getOperationName(), 1 /*benefit*/, ctx) {}
@@ -321,17 +321,10 @@ struct PipelinedWalkDecisionTreeOpLoweringPass: public PassWrapper<PipelinedWalk
   }
 };
 
-}
-
-namespace mlir
-{
-namespace decisionforest
-{
-
 void AddWalkDecisionTreeOpLoweringPass(mlir::OpPassManager &optPM) {
   optPM.addPass(std::make_unique<WalkDecisionTreeOpLoweringPass>());
   optPM.addPass(std::make_unique<PipelinedWalkDecisionTreeOpLoweringPass>());
 }
 
-}
-}
+} // namespace decisionforest
+} // namespace mlir


### PR DESCRIPTION
There were errors in the clang build due to some passes being under anonymous namespaces. Fixing that.